### PR TITLE
Willie/grant read

### DIFF
--- a/lib/cryo/store/s3.rb
+++ b/lib/cryo/store/s3.rb
@@ -15,7 +15,12 @@ class S3 < Store
     bucket  = opts[:bucket]
     key     = opts[:key]
     content = opts[:content]
-    @s3.buckets[bucket].objects[key].write(content) # TODO: verify that bucket exists?
+    # When using S3 cross-region replication across accounts
+    # (https://docs.aws.amazon.com/AmazonS3/latest/dev/crr-how-setup.html)
+    # it may be necessary to grant the destination account the
+    # ACL read permissions for each object to provide read access
+    options = { :grant_read => ENV['S3_ACL_GRANT_READ_GRANTEE'] }
+    @s3.buckets[bucket].objects[key].write(content, options)
   end
 
   # return an array listing the objects in our snapshot bucket

--- a/lib/cryo/version.rb
+++ b/lib/cryo/version.rb
@@ -1,3 +1,3 @@
 class Cryo
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end


### PR DESCRIPTION
We are now using S3's replication feature to replicate our database backup data created by cryo here. It turns out... even after an object is replicated, it belongs to the source account. This means that the destination account does not actually have read access to these files unless explicitly granted the ACL read permissions. This PR grants said permissions if the `S3_ACL_GRANT_READ_GRANTEE` env variable is provided, otherwise it just ignores the option. This was tested.

@philsno @ktrice 