### PR TITLE
[cryo] Remove aws access key from required params

### DIFF
--- a/bin/cryo
+++ b/bin/cryo
@@ -3,9 +3,7 @@
 require 'cryo'
 require 'trollop'
 
-required_parameters = %w(aws_access_key
-                         aws_secret_key
-                         host
+required_parameters = %w(host
                          password
                          snapshot_bucket
                          snapshot_prefix

--- a/lib/cryo/store/s3.rb
+++ b/lib/cryo/store/s3.rb
@@ -5,8 +5,11 @@ class S3 < Store
 
   def initialize(opts={})
     super(opts)
-    AWS.config(:access_key_id => opts[:aws_access_key],
-               :secret_access_key => opts[:aws_secret_key])
+    # Set access key only if provided, otherwise default to IAM role
+    if(opts[:aws_access_key] && opts[:aws_secret_key])
+      AWS.config(:access_key_id => opts[:aws_access_key],
+                 :secret_access_key => opts[:aws_secret_key])
+    end
     @s3 = AWS::S3.new
     @snapshot_bucket = @s3.buckets[opts[:snapshot_bucket]]
   end

--- a/lib/cryo/version.rb
+++ b/lib/cryo/version.rb
@@ -1,3 +1,3 @@
 class Cryo
-  VERSION = '0.1.11'
+  VERSION = '0.1.12'
 end


### PR DESCRIPTION
Remove aws access key from required params to allow aws-sdk to default to the instance's IAM Role. This is supported in aws-sdk 1.6.

@SonicWang 
